### PR TITLE
update rosetta_drone link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # drone_causality
 
-All training, data processing, and analysis code used for the paper "Robust Visual Flight Navigation with Liquid Neural Networks". For code run onboard the drone, see [this repository](https://github.com/GoldenZephyr/rosetta_drone).
+All training, data processing, and analysis code used for the paper "Robust Visual Flight Navigation with Liquid Neural Networks". For code run onboard the drone, see [this repository](https://github.com/makramchahine/rosetta_drone).
 
 ## Installation Instructions
 


### PR DESCRIPTION
This pull request simply updates the README to point to the public rosetta_drone fork hosted at https://github.com/makramchahine instead of the original one, which doesn't seem to be publicly available.